### PR TITLE
Upgrade to PyYAML 6.0 and Python 3

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 with import <nixpkgs> {};
 
-(python.buildEnv.override {
-  extraLibs = with pythonPackages;
+(python3.buildEnv.override {
+  extraLibs = with python3Packages;
     [ pyyaml
     ];
 }).env

--- a/yaml-merge.py
+++ b/yaml-merge.py
@@ -3,10 +3,16 @@
 import sys
 import yaml
 
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+    from yaml import Loader, Dumper
+
+
 # Mutating recursive dictionary merge
 def merge(a, b):
   if isinstance(a, dict) and isinstance(b, dict):
-    for k, v in b.iteritems():
+    for k, v in b.items():
       if k in a:
         a[k] = merge(a[k], v)
       else:
@@ -24,12 +30,12 @@ file2_name = sys.argv[2]
 # Either I don't know a better way, or Python gets ugly...
 file1 = None
 with open(file1_name) as f:
-  file1 = yaml.load(f)
+  file1 = yaml.load(f, Loader=Loader)
 
 file2 = None
 with open(file2_name) as f:
-  file2 = yaml.load(f)
+  file2 = yaml.load(f, Loader=Loader)
 
 result = merge(file1, file2)
 
-print(yaml.dump(result))
+print(yaml.dump(result, Dumper=Dumper))


### PR DESCRIPTION
nixpkgs version using [python3](https://github.com/NixOS/nixpkgs/pull/154310)

fix exception when merge yaml

```
Jan 12 03:17:31 ring adguardhome-pre-start[1479484]: Traceback (most recent call last):
Jan 12 03:17:31 ring adguardhome-pre-start[1479484]:   File "/nix/store/bkyfc9g1hhqspzfhzpaf9jgff1jmgfad-yaml-merge-unstable-2016-02-16/bin/.yaml-merge-wrapped", line 28, in <module>
Jan 12 03:17:31 ring adguardhome-pre-start[1479484]:     file1 = yaml.load(f)
Jan 12 03:17:31 ring adguardhome-pre-start[1479484]: TypeError: load() missing 1 required positional argument: 'Loader'
```